### PR TITLE
Updated to version 2.10.0, adds support for crawlable custom lists of URLs

### DIFF
--- a/com.pragmar.interrobot.yaml
+++ b/com.pragmar.interrobot.yaml
@@ -51,5 +51,5 @@ modules:
 
       # x86_64 InterroBot build
       - type: archive
-        url: https://interro.bot/media/uploads/bin/interrobot-2.10.0.0.tar.gz
-        sha256: a38af96cec67e96c758021028949eb439bf92cd609d37bcc249ce274446bf5b8
+        url: https://interro.bot/media/uploads/bin/interrobot-2.10.0.1.tar.gz
+        sha256: 4eba868f6ff53b47ea103f817ec344e621703745fe78649a87fbd9e27ff6a35a


### PR DESCRIPTION
InterroBot 2.10 adds custom URL lists as a project type.